### PR TITLE
Fix invalid plant UML generation for software systems

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "structurizr-typescript",
-  "version": "1.0.2",
+  "version": "1.0.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "structurizr-typescript",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/client/plantUML/plantUMLWriter.ts
+++ b/src/client/plantUML/plantUMLWriter.ts
@@ -169,7 +169,7 @@ export class PlantUMLWriter {
     }
 
     private nameOf(s: string): string {
-        return s ? s.replace(" ", "").replace("-", "") : "";
+        return s ? `"${s}"` : "";
     }
 
     private writeFooter(writer: StringWriter) {

--- a/test/index.ts
+++ b/test/index.ts
@@ -1,6 +1,6 @@
 import { describe, it } from "mocha";
 import { testApiCompatitbility, testApiIdempotency } from "./api-compatibility";
-import { testPlantUMLWriter } from "./plantUMLWriter";
+import { testPlantUMLWriter, testPlantUMLWriterIsAbleToHandleProperlyPackageNameWithMultipleWords } from "./plantUMLWriter";
 import { testElementStyleThemeExport, testFullThemeExport } from "./themeExport";
 import * as  deepEqualInAnyOrder from 'deep-equal-in-any-order';
 import * as chai from "chai";
@@ -17,6 +17,10 @@ describe("structurizr-typescript", () => {
     describe("client", () => {
         describe("plantUML", () => {
             it("export plant UML diagrams correctly", testPlantUMLWriter);
+            it(
+                "handles long system names properly when exporting as package in container view",
+                testPlantUMLWriterIsAbleToHandleProperlyPackageNameWithMultipleWords
+              );
         })
     });
 

--- a/test/plantUMLWriter.ts
+++ b/test/plantUMLWriter.ts
@@ -1,8 +1,18 @@
 import { expect } from "chai";
-import { PlantUMLWriter } from "../src";
-import { createWorkspace } from "./workspace";
+import { PlantUMLWriter, Workspace, Location, SoftwareSystem } from "../src";
+import { createWorkspace, createWorkspaceWithSoftwareSystemNameOfMoreThanTwoWords } from "./workspace";
 
 export function testPlantUMLWriter() {
-    const plantUML = new PlantUMLWriter().toPlantUML(createWorkspace());
-    expect(plantUML).not.to.be.empty;
+  const plantUML = new PlantUMLWriter().toPlantUML(createWorkspace());
+  expect(plantUML).not.to.be.empty;
 }
+
+export function testPlantUMLWriterIsAbleToHandleProperlyPackageNameWithMultipleWords() {
+  const workspace: Workspace = createWorkspaceWithSoftwareSystemNameOfMoreThanTwoWords();
+
+  const expected = "@startuml\r\ntitle GPS tracking system - Containers\r\ncaption Container view for the GPS tracking system\r\npackage \"GPS tracking system\" {\r\n}\r\n@enduml";
+  const result = new PlantUMLWriter().toPlantUML(workspace);
+
+  expect(result.trim()).to.eq(expected);
+}
+

--- a/test/plantUMLWriter.ts
+++ b/test/plantUMLWriter.ts
@@ -1,5 +1,5 @@
 import { expect } from "chai";
-import { PlantUMLWriter, Workspace, Location, SoftwareSystem } from "../src";
+import { PlantUMLWriter, Workspace } from "../src";
 import { createWorkspace, createWorkspaceWithSoftwareSystemNameOfMoreThanTwoWords } from "./workspace";
 
 export function testPlantUMLWriter() {

--- a/test/workspace.ts
+++ b/test/workspace.ts
@@ -104,12 +104,12 @@ export const createWorkspace: () => Workspace = () => {
 export const createWorkspaceWithSoftwareSystemNameOfMoreThanTwoWords: () => Workspace = () => {
     const workspace: Workspace = new Workspace();
     workspace.name = "GPS tracking system";
-    const GPSTrackingSystem: SoftwareSystem = workspace.model.addSoftwareSystem("GPS tracking system", "Ingests, processes and visualizes GPS tracking data") as SoftwareSystem;
-    GPSTrackingSystem.location = Location.Internal;
+    const gpsTrackingSystem: SoftwareSystem = workspace.model.addSoftwareSystem("GPS tracking system", "Ingests, processes and visualizes GPS tracking data") as SoftwareSystem;
+    gpsTrackingSystem.location = Location.Internal;
     
-    const containerView = workspace.views.createContainerView(GPSTrackingSystem, "gps-tracking-system-containers", "Container view for the GPS tracking system");
+    const containerView = workspace.views.createContainerView(gpsTrackingSystem, "gps-tracking-system-containers", "Container view for the GPS tracking system");
     containerView.addAllContainers();
-    containerView.addNearestNeighbours(GPSTrackingSystem);
+    containerView.addNearestNeighbours(gpsTrackingSystem);
 
     return workspace;
 }

--- a/test/workspace.ts
+++ b/test/workspace.ts
@@ -1,4 +1,4 @@
-import { Workspace, Location, InteractionStyle, ElementStyle, RelationshipStyle, Shape, Tags, Format, DecisionStatus, RankDirection, FilterMode, PaperSize } from "../src";
+import { Workspace, Location, InteractionStyle, ElementStyle, RelationshipStyle, Shape, Tags, Format, DecisionStatus, RankDirection, FilterMode, PaperSize, SoftwareSystem } from "../src";
 
 export const createWorkspace: () => Workspace = () => {
     const workspace = new Workspace();
@@ -97,6 +97,19 @@ export const createWorkspace: () => Workspace = () => {
     workspace.documentation.addDecision(undefined, '2', new Date('2008-09-15T15:53:00'), 'Use angular as the frontend framework', DecisionStatus.Proposed, Format.Markdown, `We should use angular`);
 
     workspace.views.configuration.terminology.person = "Actor";
+
+    return workspace;
+}
+
+export const createWorkspaceWithSoftwareSystemNameOfMoreThanTwoWords: () => Workspace = () => {
+    const workspace: Workspace = new Workspace();
+    workspace.name = "GPS tracking system";
+    const GPSTrackingSystem: SoftwareSystem = workspace.model.addSoftwareSystem("GPS tracking system", "Ingests, processes and visualizes GPS tracking data") as SoftwareSystem;
+    GPSTrackingSystem.location = Location.Internal;
+    
+    const containerView = workspace.views.createContainerView(GPSTrackingSystem, "gps-tracking-system-containers", "Container view for the GPS tracking system");
+    containerView.addAllContainers();
+    containerView.addNearestNeighbours(GPSTrackingSystem);
 
     return workspace;
 }


### PR DESCRIPTION
When software system had name longer than 2 words, an invalid package name in plantUML was generated.

This pull request wraps software system name in quotes (like in the examples for Grouping Components here: https://plantuml.com/component-diagram ) instead of only removing first space or first dash character.